### PR TITLE
Add 3D GPU Navier-Stokes solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Navier-Stokes Vorticity Simulator
+
+A minimal 3D incompressible Navier-Stokes solver using spectral methods and PyTorch.
+
+## Requirements
+- Python 3.8+
+- PyTorch with CUDA support for GPU acceleration (CPU works but is slower)
+
+## Usage
+```
+python main.py --N 64 --L 6.283 --nu 0.01 --dt 1e-3 --T 0.1
+```
+All arguments are optional. The solver starts from a 3D Taylor–Green vortex and prints final diagnostics.

--- a/initial_conditions.py
+++ b/initial_conditions.py
@@ -1,0 +1,14 @@
+import torch
+import math
+
+
+def taylor_green(N: int, L: float, device: torch.device, amplitude: float = 1.0) -> torch.Tensor:
+    """Return 3D Taylor-Green vortex initial velocity field."""
+    x = torch.linspace(0, L, N, device=device, dtype=torch.float32)
+    grid = torch.meshgrid(x, x, x, indexing='ij')
+    X, Y, Z = grid
+    factor = 2 * math.pi / L
+    u_x =  amplitude * torch.sin(factor * X) * torch.cos(factor * Y) * torch.cos(factor * Z)
+    u_y = -amplitude * torch.cos(factor * X) * torch.sin(factor * Y) * torch.cos(factor * Z)
+    u_z = torch.zeros_like(u_x)
+    return torch.stack([u_x, u_y, u_z], dim=0)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,28 @@
+import argparse
+import torch
+from solver import run_simulation
+from initial_conditions import taylor_green
+
+
+def main():
+    parser = argparse.ArgumentParser(description="3D Navier-Stokes Vorticity Simulator (GPU)")
+    parser.add_argument('--N', type=int, default=64, help='Grid points per dimension')
+    parser.add_argument('--L', type=float, default=2 * 3.141592653589793, help='Domain size')
+    parser.add_argument('--nu', type=float, default=0.01, help='Viscosity')
+    parser.add_argument('--dt', type=float, default=1e-3, help='Time step')
+    parser.add_argument('--T', type=float, default=0.1, help='Final time')
+    parser.add_argument('--amplitude', type=float, default=1.0, help='Initial velocity amplitude')
+    args = parser.parse_args()
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    u0 = taylor_green(args.N, args.L, device, amplitude=args.amplitude)
+    u0 = u0.to(device)
+    u, diagnostics = run_simulation(u0, args.nu, args.dt, args.T, args.L, device)
+
+    print("Final energy: {:.6f}".format(diagnostics['energy'][-1]))
+    print("Max vorticity: {:.6f}".format(max(diagnostics['max_vorticity'])))
+
+
+if __name__ == '__main__':
+    main()

--- a/solver.py
+++ b/solver.py
@@ -1,0 +1,83 @@
+import torch
+import torch.fft as fft
+
+
+def spectral_laplacian(u: torch.Tensor, k2: torch.Tensor) -> torch.Tensor:
+    """Return Laplacian of velocity field using spectral multiplication."""
+    u_hat = fft.fftn(u, dim=(-3, -2, -1))
+    lap_hat = -k2 * u_hat
+    return torch.real(fft.ifftn(lap_hat, dim=(-3, -2, -1)))
+
+
+def project(u: torch.Tensor, kx: torch.Tensor, ky: torch.Tensor, kz: torch.Tensor, k2: torch.Tensor) -> torch.Tensor:
+    """Helmholtz-Hodge projection to enforce divergence-free condition."""
+    u_hat = fft.fftn(u, dim=(-3, -2, -1))
+    div_hat = kx * u_hat[0] + ky * u_hat[1] + kz * u_hat[2]
+    factor = div_hat / (k2 + 1e-10)
+    u_hat[0] -= kx * factor
+    u_hat[1] -= ky * factor
+    u_hat[2] -= kz * factor
+    u = torch.real(fft.ifftn(u_hat, dim=(-3, -2, -1)))
+    return u
+
+
+def derivatives(u: torch.Tensor, dx: float):
+    dudx = (torch.roll(u, -1, dims=1) - torch.roll(u, 1, dims=1)) / (2 * dx)
+    dudy = (torch.roll(u, -1, dims=2) - torch.roll(u, 1, dims=2)) / (2 * dx)
+    dudz = (torch.roll(u, -1, dims=3) - torch.roll(u, 1, dims=3)) / (2 * dx)
+    return dudx, dudy, dudz
+
+
+def curl(u: torch.Tensor, dx: float) -> torch.Tensor:
+    dudx, dudy, dudz = derivatives(u, dx)
+    omega_x = dudy[2] - dudz[1]
+    omega_y = dudz[0] - dudx[2]
+    omega_z = dudx[1] - dudy[0]
+    return torch.stack([omega_x, omega_y, omega_z], dim=0)
+
+
+def run_simulation(u: torch.Tensor, nu: float, dt: float, T: float, L: float, device: torch.device):
+    """Run 3D Navier-Stokes simulation with RK2."""
+    N = u.shape[1]
+    dx = L / N
+    steps = int(T / dt)
+
+    k = torch.fft.fftfreq(N, d=dx, device=device) * 2 * torch.pi
+    kx, ky, kz = torch.meshgrid(k, k, k, indexing='ij')
+    k2 = kx ** 2 + ky ** 2 + kz ** 2
+
+    diagnostics = {"max_vorticity": [], "enstrophy": [], "energy": []}
+
+    u = project(u, kx, ky, kz, k2)
+
+    for _ in range(steps):
+        dudx, dudy, dudz = derivatives(u, dx)
+        adv_x = u[0] * dudx[0] + u[1] * dudy[0] + u[2] * dudz[0]
+        adv_y = u[0] * dudx[1] + u[1] * dudy[1] + u[2] * dudz[1]
+        adv_z = u[0] * dudx[2] + u[1] * dudy[2] + u[2] * dudz[2]
+        adv = torch.stack([adv_x, adv_y, adv_z], dim=0)
+        lap = spectral_laplacian(u, k2)
+        rhs = -adv + nu * lap
+        u_star = u + dt * rhs
+        u_star = project(u_star, kx, ky, kz, k2)
+
+        dudx_s, dudy_s, dudz_s = derivatives(u_star, dx)
+        adv_x = u_star[0] * dudx_s[0] + u_star[1] * dudy_s[0] + u_star[2] * dudz_s[0]
+        adv_y = u_star[0] * dudx_s[1] + u_star[1] * dudy_s[1] + u_star[2] * dudz_s[1]
+        adv_z = u_star[0] * dudx_s[2] + u_star[1] * dudy_s[2] + u_star[2] * dudz_s[2]
+        adv_s = torch.stack([adv_x, adv_y, adv_z], dim=0)
+        lap_s = spectral_laplacian(u_star, k2)
+        rhs_s = -adv_s + nu * lap_s
+
+        u = u + dt * 0.5 * (rhs + rhs_s)
+        u = project(u, kx, ky, kz, k2)
+
+        omega = curl(u, dx)
+        max_vort = omega.abs().max().item()
+        enstrophy = 0.5 * torch.sum(omega ** 2) * dx ** 3
+        energy = 0.5 * torch.sum(u ** 2) * dx ** 3
+        diagnostics["max_vorticity"].append(max_vort)
+        diagnostics["enstrophy"].append(enstrophy.item())
+        diagnostics["energy"].append(energy.item())
+
+    return u, diagnostics


### PR DESCRIPTION
## Summary
- add GPU-ready spectral 3D Navier-Stokes solver using PyTorch
- include Taylor--Green initial condition and simple CLI
- document requirements and usage

## Testing
- `python main.py --N 8 --T 0.01 --dt 0.005` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684df8e840c8832fa3d765aae6f66795