### PR TITLE
Add GitHub Sponsors configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: RDM3DC

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Navier-Stokes Vorticity Simulator
 
+[![Sponsor](https://img.shields.io/badge/sponsor-RDM3DC-EA4AAA?logo=github-sponsors)](https://github.com/sponsors/RDM3DC)
+
 A minimal 3D incompressible Navier-Stokes solver using spectral methods and PyTorch.
 
 ## Requirements


### PR DESCRIPTION
## Summary
- add GitHub Sponsors link to README
- configure GitHub Sponsors via FUNDING.yml

## Testing
- `python -m py_compile initial_conditions.py solver.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8e54b345c832fbddbb8daaaf86a1f